### PR TITLE
7 이메일 api 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "ioredis": "^5.6.0",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "nodemailer": "^6.10.0"

--- a/src/controllers/email.controller.js
+++ b/src/controllers/email.controller.js
@@ -28,7 +28,7 @@ class EmailController {
       const { verifyNumber } = req.body;
 
       // 인증 번호 일치하는지 확인에 필요한 유저 ID 가져오기
-      const userId = req.user.userId;
+      const userId = req.user.id;
 
       const verifyCryptogram = await this.emailService.verifyCryptogram(
         verifyNumber,

--- a/src/controllers/email.controller.js
+++ b/src/controllers/email.controller.js
@@ -28,11 +28,11 @@ class EmailController {
       const { verifyNumber } = req.body;
 
       // 인증 번호 일치하는지 확인에 필요한 유저 ID 가져오기
-      const userId = req.user.id;
+      const userEmail = req.user.email;
 
       const verifyCryptogram = await this.emailService.verifyCryptogram(
         verifyNumber,
-        userId,
+        userEmail,
       );
       return res.status(HTTP_STATUS.OK).json({
         status: HTTP_STATUS.OK,

--- a/src/controllers/email.controller.js
+++ b/src/controllers/email.controller.js
@@ -9,8 +9,13 @@ class EmailController {
     try {
       // 학생 이메일 가져오기
       const { email } = req.body;
-      const requestVerification =
-        await this.emailService.requestVerification(email);
+
+      // 선생님 정보 가져오기
+      const user = req.user;
+      const requestVerification = await this.emailService.requestVerification(
+        email,
+        user,
+      );
       return res.status(HTTP_STATUS.OK).json({
         status: HTTP_STATUS.OK,
         message: '이메일 인증 코드 요청 완료',
@@ -28,11 +33,11 @@ class EmailController {
       const { verifyNumber } = req.body;
 
       // 인증 번호 일치하는지 확인에 필요한 유저 ID 가져오기
-      const userEmail = req.user.email;
+      const user = req.user;
 
       const verifyCryptogram = await this.emailService.verifyCryptogram(
         verifyNumber,
-        userEmail,
+        user,
       );
       return res.status(HTTP_STATUS.OK).json({
         status: HTTP_STATUS.OK,

--- a/src/controllers/email.controller.js
+++ b/src/controllers/email.controller.js
@@ -20,6 +20,28 @@ class EmailController {
       next(err);
     }
   };
+
+  // 이메일 인증 확인 요청 API - 학생 권한
+  verifyCryptogram = async (req, res, next) => {
+    try {
+      // 인증 번호 가져오기
+      const { verifyNumber } = req.body;
+
+      // 인증 번호 일치하는지 확인에 필요한 유저 ID 가져오기
+      const userId = req.user.userId;
+
+      const verifyCryptogram = await this.emailService.verifyCryptogram(
+        verifyNumber,
+        userId,
+      );
+      return res.status(HTTP_STATUS.OK).json({
+        status: HTTP_STATUS.OK,
+        message: '이메일 인증 확인 요청 완료',
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
 }
 
 export default EmailController;

--- a/src/middlewares/require-access-token.middleware.js
+++ b/src/middlewares/require-access-token.middleware.js
@@ -2,8 +2,9 @@ import jwt from 'jsonwebtoken';
 import { HTTP_STATUS } from '../constants/http-status.constant.js';
 import { MESSAGES } from '../constants/message.constant.js';
 import { ACCESS_TOKEN_SECRET } from '../constants/env.constant.js';
-import { AuthRepository } from '../repositories/auth.repository.js';
-
+import AuthRepository from '../repositories/auth.repository.js';
+import { prisma } from '../utils/prisma.utils.js';
+const authRepository = new AuthRepository(prisma);
 export const requireAccessToken = async (req, res, next) => {
   try {
     const authorization = req.headers.authorization;
@@ -53,7 +54,7 @@ export const requireAccessToken = async (req, res, next) => {
 
     // payload에 담긴 사용자 id와 일치하는 사용자가 없는 경우
     const { id } = payload;
-    const user = await AuthRepository.findUserById(id);
+    const user = await authRepository.findUserById(id);
 
     if (!user) {
       return res.status(HTTP_STATUS.UNAUTHORIZED).json({

--- a/src/repositories/email.repository.js
+++ b/src/repositories/email.repository.js
@@ -1,3 +1,3 @@
-class EmailRepository{}
+class EmailRepository {}
 
-export default EmailRepository
+export default EmailRepository;

--- a/src/repositories/email.repository.js
+++ b/src/repositories/email.repository.js
@@ -1,3 +1,19 @@
-class EmailRepository {}
+import { prisma } from '../utils/prisma.utils.js';
+
+class EmailRepository {
+  // 수업정보 생성
+  createClass = async (teacherId, subject, userId) => {
+    console.log(teacherId, subject, userId);
+    const classInformation = await prisma.class.create({
+      data: {
+        studentId: userId,
+        teacherId,
+        subject,
+      },
+    });
+    console.log('zz');
+    return classInformation;
+  };
+}
 
 export default EmailRepository;

--- a/src/routers/email.router.js
+++ b/src/routers/email.router.js
@@ -11,7 +11,11 @@ const emailService = new EmailService(emailRepository);
 const emailController = new EmailController(emailService);
 
 // 이메일 인증 코드 요청 API - 선생님 권한
-emailRouter.post('/request-verification', emailController.requestVerification);
+emailRouter.post(
+  '/request-verification',
+  requireAccessToken,
+  emailController.requestVerification,
+);
 
 // 이메일 인증 코드 확인 API - 학생권한
 emailRouter.post(

--- a/src/routers/email.router.js
+++ b/src/routers/email.router.js
@@ -3,6 +3,7 @@ import EmailRepository from '../repositories/email.repository.js';
 import { prisma } from '../utils/prisma.utils.js';
 import EmailService from '../services/email.service.js';
 import EmailController from '../controllers/email.controller.js';
+import { requireAccessToken } from '../middlewares/require-access-token.middleware.js';
 
 const emailRouter = express.Router();
 const emailRepository = new EmailRepository(prisma);
@@ -13,5 +14,9 @@ const emailController = new EmailController(emailService);
 emailRouter.post('/request-verification', emailController.requestVerification);
 
 // 이메일 인증 코드 확인 API - 학생권한
-//emailController.post('/verify-code');
+emailRouter.post(
+  '/verify-code',
+  requireAccessToken,
+  emailController.verifyCryptogram,
+);
 export { emailRouter };

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -12,13 +12,15 @@ class EmailService {
   // 이메일 인증 코드 요청 API - 선생님 권한
   requestVerification = async (email) => {
     // 유저 데이터에 email을 조회한 후, 있으면 통과 없으면 에러 처리
-    // 추후 구현
+    const existedEmail = await this.authRepository.findUserByEmail(email);
+    if (!existedEmail) throw new NotFoundError('이메일이 존재하지 않습니다.');
 
+    /*
     // 구글 활용을 위해 아이디, 비밀번호 세팅
-    // const googleEmail = process.env.GOOGLE_EMAIL;
-    // const googlePassword = process.env.GOOGLE_PASSWORD;
-    // const emailService = process.env.EMAIL_SERVICE;
-
+    const googleEmail = process.env.GOOGLE_EMAIL;
+    const googlePassword = process.env.GOOGLE_PASSWORD;
+    const emailService = process.env.EMAIL_SERVICE;
+    */
     // 인증 코드 생성
     const cryptogram = generate4DigitRandom();
 
@@ -28,31 +30,33 @@ class EmailService {
     const value = cryptogram;
     redis.set(key, value, 'EX', 600); // 600초 = 10분 TTL
 
+    /*
     // createTransport = 메일 서버와 연결 설정, auth는 계정의 아이디 비번를 확인
-    // const transporter = nodemailer.createTransport({
-    //   service: emailService,
-    //   auth: {
-    //     user: googleEmail,
-    //     pass: googlePassword,
-    //   },
-    // });
+    const transporter = nodemailer.createTransport({
+      service: emailService,
+      auth: {
+        user: googleEmail,
+        pass: googlePassword,
+      },
+    });
 
     // mailOption = 보낼 메일의 내용 설정
-    // const mailOptions = {
-    //   from: googleEmail, //작성자
-    //   to: email, // 수신자
-    //   subject: 'Nodemailer Test', // 메일 제목
-    //   text: cryptogram, // 메일 내용
-    // };
+    const mailOptions = {
+      from: googleEmail, //작성자
+      to: email, // 수신자
+      subject: 'Nodemailer Test', // 메일 제목
+      text: cryptogram, // 메일 내용
+    };
 
     // sendMail = 실제로 메일을 보내는 함수
-    // transporter.sendMail(mailOptions, (error, info) => {
-    //   if (error) {
-    //     console.error(error);
-    //   } else {
-    //     console.log('Email Sent : ', info);
-    //   }
-    // });
+    transporter.sendMail(mailOptions, (error, info) => {
+      if (error) {
+        console.error(error);
+      } else {
+        console.log('Email Sent : ', info);
+      }
+    });
+    */
 
     return cryptogram;
   };

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -62,11 +62,7 @@ class EmailService {
   };
 
   // 이메일 인증 확인 요청 API - 학생 권한
-  verifyCryptogram = async (verifyNumber, userId) => {
-    // 레디스 set할때, 이메일이 key이기 때문에 유저 이메일 가져오기
-    const user = await this.authRepository.findUserById(userId);
-    const userEmail = user.email;
-
+  verifyCryptogram = async (verifyNumber, userEmail) => {
     // email로 가져온 key값으로 value( 인증번호 ) 찾기
     const key = `cryptogram:${userEmail}`;
     const redis = new Redis();

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -10,7 +10,7 @@ class EmailService {
   authRepository = new AuthRepository();
 
   // 이메일 인증 코드 요청 API - 선생님 권한
-  requestVerification = async (email) => {
+  requestVerification = async (email, user) => {
     // 유저 데이터에 email을 조회한 후, 있으면 통과 없으면 에러 처리
     const existedEmail = await this.authRepository.findUserByEmail(email);
     if (!existedEmail) throw new NotFoundError('이메일이 존재하지 않습니다.');
@@ -21,15 +21,18 @@ class EmailService {
     const googlePassword = process.env.GOOGLE_PASSWORD;
     const emailService = process.env.EMAIL_SERVICE;
     */
-    // 인증 코드 생성
+    // 인증 코드 생성 및 선생님 데이터 추가
     const cryptogram = generate4DigitRandom();
 
     // redis를 활용해 인증 번호를 10분동안만 저장
     const redis = new Redis();
     const key = `cryptogram:${email}`;
-    const value = cryptogram;
-    redis.set(key, value, 'EX', 600); // 600초 = 10분 TTL
+    const value = JSON.stringify({
+      ...user,
+      cryptogram,
+    });
 
+    await redis.set(key, value, 'EX', 600); // 600초 = 10분 TTL
     /*
     // createTransport = 메일 서버와 연결 설정, auth는 계정의 아이디 비번를 확인
     const transporter = nodemailer.createTransport({
@@ -62,26 +65,41 @@ class EmailService {
   };
 
   // 이메일 인증 확인 요청 API - 학생 권한
-  verifyCryptogram = async (verifyNumber, userEmail) => {
+  verifyCryptogram = async (verifyNumber, user) => {
     // email로 가져온 key값으로 value( 인증번호 ) 찾기
+    const userEmail = user.email;
+    const userId = user.id;
     const key = `cryptogram:${userEmail}`;
     const redis = new Redis();
     const value = await redis.get(key);
 
+    // JSON parse로 값 꺼내기
+    const parsed = JSON.parse(value);
+    const cryptogram = parsed.cryptogram;
+    const teacherId = parsed.id;
+    const subject = parsed.subject;
+
     // 만약 인증코드가 만료되었다면 에러처리
-    if (!value) {
+    if (!cryptogram) {
       throw new NotFoundError('인증코드가 만료되었거나 존재하지 않습니다.');
     }
 
     // 인증코드가 입력한 숫자와 다르다면 에러처리
-    if (value !== verifyNumber) {
+    if (cryptogram !== verifyNumber) {
       throw new ConflictError('인증 코드가 일치하지 않습니다.');
     }
 
-    // 검증 성공했다면 인증 처리 후, 인증 코드 삭제
+    // 검증 성공했기에 수업 테이블에 데이터 저장
+    // 선생님 ID, 학생 ID, 과목
+    const classData = await this.emailRepository.createClass(
+      teacherId,
+      subject,
+      userId,
+    );
+    // 인증 처리 후, 인증 코드 삭제
     await redis.del;
 
-    return;
+    return classData;
   };
 }
 // 인증 코드 구현

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,11 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@mapbox/node-pre-gyp@^1.0.11":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
@@ -368,6 +373,11 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 color-support@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
@@ -431,6 +441,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
+
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0:
   version "2.0.0"
@@ -771,6 +786,21 @@ inherits@2, inherits@2.0.4, inherits@^2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ioredis@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.6.0.tgz#faa2a27132f8a05c0ddfef400b01d1326df211a0"
+  integrity sha512-tBZlIIWbndeWBWCXWZiqtOF/yxf6yZX3tAlTJ7nfo5jhd6dctNxF7QnYlZLZ1a0o0pDoen7CgZqO+zjNaFbJAg==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -849,10 +879,20 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
   integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -1140,6 +1180,18 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -1257,6 +1309,11 @@ simple-update-notifier@^2.0.0:
   integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
   dependencies:
     semver "^7.5.3"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 statuses@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
# #️⃣연관된 이슈

7

## 📝작업 내용

- 이메일 인증 코드 요청 API
- 이메일 인증 확인 요청 API
- 인증 생성 코드 구현
- requireAccessToken 미들웨어 관련된 오류 처리


## 시나리오

1. 선생님이 학생의 이메일을 입력해, 그 이메일로 인증 코드 요청 ( 이메일 인증 코드 요청 API 사용 )
2. 학생은 인증코드를 확인하고 입력 ( 이메일 인증 확인 요청 API 사용 )
3. 실패할 경우 에러처리
4. 성공할 경우 '수업'데이터에 데이터가 생성된다.


## 핵심적인 패키지

### nodemailer
nodemailer는 학생에게 인증코드를 전달하는 역할로 사용할 예정이었으나,

pop3 등 매우 귀찮은 설정이 많아 처음 연결만 성공 후, 사진으로 남겨둠 ( 지금은 연결 해지 상태 )

### ioredis
ioredis는 인증코드를 10분동안만 유지시키고자 하는 목표

redis의 TTL 기능으로 10분 혹은 인증 성공시 삭제하기 위해 설치한 패키지 



## 리뷰 요구사항(선택)


